### PR TITLE
Remove $PSScriptRoot references to enable exiftool usage via PATH

### DIFF
--- a/MotionPhoto2.ps1
+++ b/MotionPhoto2.ps1
@@ -29,7 +29,7 @@ function getStillImageTime(
     [Parameter(Mandatory=$true)]
     [string] $mov
 ) {
-    [String[]]$out = runCmdAndCaptureOutput "$($PSScriptRoot)\exiftool -X -ee -n -QuickTime:StillImageTime -QuickTime:TrackDuration ""$($mov)"""
+    [String[]]$out = runCmdAndCaptureOutput "exiftool -X -ee -n -QuickTime:StillImageTime -QuickTime:TrackDuration ""$($mov)"""
     [String] $presentationTimestampText = "#NaN"
     [Int] $presentationTimestamp = 0
     [String] $trackNumber = "Missing"
@@ -189,7 +189,7 @@ Copy-Item $imageFile -Destination "$($outputFile).tmp1"
 Remove-Item -ErrorAction Ignore "$($outputFile).tmp2" 
 
 # Copy attributes from existing XMP file
-$existingXmpString = runCmdAndCaptureOutput "$($PSScriptRoot)\exiftool -XMP -b ""$($outputFile).tmp1""" 
+$existingXmpString = runCmdAndCaptureOutput "exiftool -XMP -b ""$($outputFile).tmp1""" 
 try { 
     $existingXmp = [XML] $existingXmpString
     ForEach ($XmlNode in $existingXmp.xmpmeta.RDF.Description.ChildNodes) {
@@ -205,7 +205,7 @@ try {
 $xmp.Save("$($outputFile).tmp2")
 
 # Replace XMP attributes in the still image file with above new XMP
-runCmdAndCaptureOutput "$($PSScriptRoot)\exiftool -overwrite_original -tagsfromfile ""$($outputFile).tmp2"" -xmp ""$($outputFile).tmp1""" | Out-Null
+runCmdAndCaptureOutput "exiftool -overwrite_original -tagsfromfile ""$($outputFile).tmp2"" -xmp ""$($outputFile).tmp1""" | Out-Null
 
 Write-Output "Stitching image and video together into MotionPhoto..."
 


### PR DESCRIPTION
This pull request removes $PSScriptRoot references, allowing the script to use exiftool from the system's PATH while still supporting an executable located in the script's directory.