### PR TITLE
Handling filenames that contain dots

### DIFF
--- a/motionphoto2.py
+++ b/motionphoto2.py
@@ -230,7 +230,7 @@ def main():
                 
                 for video_name in possible_video_names:
                     for ext in [".mp4", ".mov", ".MP4", ".MOV"]:
-                        video_fname = f"{Path(video_name).with_suffix(ext)}"
+                        video_fname = str(Path(video_name)) + f"{ext}"
                         if video_fname in videos:
                             print(f"=========================[{i}/{len(images)}]")
                             video = videos.pop(videos.index(video_fname))

--- a/motionphoto2.py
+++ b/motionphoto2.py
@@ -230,7 +230,7 @@ def main():
                 
                 for video_name in possible_video_names:
                     for ext in [".mp4", ".mov", ".MP4", ".MOV"]:
-                        video_fname = str(Path(video_name)) + f"{ext}"
+                        video_fname = str(Path(video_name)) + ext
                         if video_fname in videos:
                             print(f"=========================[{i}/{len(images)}]")
                             video = videos.pop(videos.index(video_fname))

--- a/motionphoto2.py
+++ b/motionphoto2.py
@@ -230,7 +230,7 @@ def main():
                 
                 for video_name in possible_video_names:
                     for ext in [".mp4", ".mov", ".MP4", ".MOV"]:
-                        video_fname = str(Path(video_name)) + ext
+                        video_fname = video_name + ext
                         if video_fname in videos:
                             print(f"=========================[{i}/{len(images)}]")
                             video = videos.pop(videos.index(video_fname))


### PR DESCRIPTION
If the input image filename contains one or more dots, with_suffix removes everything after the last dot in the filename. This would result in the incorrect video filename being searched.