### PR TITLE
Fix --overwrite and --delete-video parameters not being able to be used

### DIFF
--- a/motionphoto2.py
+++ b/motionphoto2.py
@@ -223,11 +223,11 @@ def main():
         print("[ERROR] Output file cannot be use overwrite option")
         sys.exit(1)
 
-    if args.copy_unmuxed is not None and args.overwrite is True:
+    if args.copy_unmuxed is True and args.overwrite is True:
         print("[ERROR] Copy Unmuxed cannot be used with overwrite option")
         sys.exit(1)
 
-    if args.copy_unmuxed is not None and args.delete_video is True:
+    if args.copy_unmuxed is True and args.delete_video is True:
         print("[ERROR] Copy Unmuxed cannot be used with delete-video option")
         sys.exit(1)
 


### PR DESCRIPTION
The --overwrite and --delete-video parameters can't be used with --copy-unmuxed, however the check to ensure --copy-unmuxed wasn't specified was wrong causing these parameters not to be able to be specified.

The check is now corrected allowing both --overwrite and --delete-video to now be able to be used.